### PR TITLE
add chomp

### DIFF
--- a/lib/bluebutton.rb
+++ b/lib/bluebutton.rb
@@ -71,7 +71,7 @@ class Finder
 
   def from_sys
     finded = Dir.glob("/sys/**/name").select do |file|
-      File.read(file).downcase[@name.downcase]
+      File.read(file).downcase.chomp[@name.downcase]
     end.first
 
     raise "Can't find device info '#{@name}' in /sys/**/*" if finded.nil?


### PR DESCRIPTION
Thank you very nice gem.

For some reason, the AB shutter I have outputs a newline code.
 So I'd like you to add a "chomp" at one point.
I think this might be useful to someone else, so I'll make a pull request.

part of   /sys/**/name output
"cpu_thermal\n"
"(s) dummy device\n"
"ab shutter3\n"        <-need chomp
"fixedregulator_3v3\u0000"
